### PR TITLE
script to calculate contracts bytecode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5605,9 +5605,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minipass": {
       "version": "2.9.0",
@@ -5650,6 +5650,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "mkdirp-promise": {
@@ -6131,6 +6138,12 @@
         "wordwrap": "~0.0.2"
       },
       "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "^2.4.0",
     "chainlink": "0.7.10",
+    "minimist": "^1.2.0",
     "promptly": "^3.0.3",
     "truffle": "^5.0.44"
   },

--- a/scripts/local/CalculateContractBytecode.js
+++ b/scripts/local/CalculateContractBytecode.js
@@ -1,0 +1,24 @@
+// This simple script tells you how big your contract byte code is and how much you have until you exceed
+// the current block limit as defined by EIP170.
+
+const argv = require("minimist")(process.argv.slice(), { string: ["contract"] });
+const contractName = argv.contract;
+
+if (!contractName) {
+  console.log("Please enter the contract name as a parameter as `--contract <name>`.");
+  return;
+}
+var child = require("child_process").exec("truffle compile");
+child.stdout.pipe(process.stdout);
+child.on("exit", function() {
+  console.log("finished compiling 🚀!");
+  console.log("loading", contractName + ".json");
+  let obj = require("./../../build/contracts/" + contractName + ".json");
+
+  const byteCodeSize = (obj.bytecode.length - 2) / 2;
+  const remainingSize = 2 ** 14 + 2 ** 13 - (obj.bytecode.length - 2) / 2;
+  console.log("Contract is", byteCodeSize, "bytes in size.");
+  console.log("This leaves a total of", remainingSize, "bytes within the EIP170 limit 🔥.");
+
+  process.exit();
+});


### PR DESCRIPTION
## Description

This script enables quick checking of byte code size and validation if the contract is currently below the block limit defined by EIP170. It can be run from the core directory by specifying the contract name you wish to check.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

As an example to test the added script, to find the bytecode size of the AlkemiNetwork.sol build created by truffle. You would run the following from root directory of the project:

```
node scripts/local/CalculateContractBytecode.js --contract AlkemiNetwork
```

the output:

```
Compiling your contracts...
===========================
> Everything is up to date, there is nothing to compile.

finished compiling 🚀!
loading AlkemiNetwork.json
Contract is 14166 bytes in size.
This leaves a total of 10410 bytes within the EIP170 limit 🔥.
```

