### PR TITLE
add reserve creating time

### DIFF
--- a/contracts/AlkemiNetwork.sol
+++ b/contracts/AlkemiNetwork.sol
@@ -140,6 +140,7 @@ contract AlkemiNetwork is LiquidityReserveFactory {
         address _linkToken,
         address _beneficiary,
         address _asset,
+        uint256 _createdAt,
         uint256 _lockingPeriod,
         uint256 _lockingPrice,
         uint8 _lockingPricePosition
@@ -150,6 +151,7 @@ contract AlkemiNetwork is LiquidityReserveFactory {
             address(this),
             _beneficiary,
             _asset,
+            _createdAt,
             _lockingPeriod,
             _lockingPrice,
             _lockingPricePosition

--- a/contracts/liquidity-reserve/LiquidityReserve.sol
+++ b/contracts/liquidity-reserve/LiquidityReserve.sol
@@ -18,6 +18,7 @@ contract LiquidityReserve is ChainlinkClient, LiquidityReserveState {
 
     address public asset;
     address public beneficiary;
+    uint256 public createdAt;
     uint256 public lockingPeriod;
     uint256 public lockingPrice;
     uint256 public totalBalance;
@@ -62,9 +63,12 @@ contract LiquidityReserve is ChainlinkClient, LiquidityReserveState {
 
     /**
      * @notice constructor
+     * @param _link LINK token address
      * @param _liquidityProvider liquidity provider address
      * @param _alkemiNetwork Alkemi Network contract address
      * @param _beneficiary earnings beneficiary (address(0) if the earnings goes to the current reserve address)
+     * @param _asset reserve asset
+     * @param _createdAt reserve created time
      * @param _lockingPeriod funds locking period
      * @param _lockingPrice release funds when hitting this price
      * @param _lockingPricePosition locking price position
@@ -75,6 +79,7 @@ contract LiquidityReserve is ChainlinkClient, LiquidityReserveState {
         address _alkemiNetwork,
         address _beneficiary,
         address _asset,
+        uint256 _createdAt,
         uint256 _lockingPeriod,
         uint256 _lockingPrice,
         uint8 _lockingPricePosition
@@ -96,6 +101,7 @@ contract LiquidityReserve is ChainlinkClient, LiquidityReserveState {
 
         asset = _asset;
         beneficiary = _beneficiary;
+        createdAt = _createdAt;
         lockingPeriod = _lockingPeriod;
         lockingPrice = _lockingPrice;
 
@@ -144,10 +150,11 @@ contract LiquidityReserve is ChainlinkClient, LiquidityReserveState {
     function details()
         public
         view
-        returns (address, uint256, uint256, uint256, uint256, uint256)
+        returns (address, uint256, uint256, uint256, uint256, uint256, uint256)
     {
         return (
             asset,
+            createdAt,
             lockingPeriod,
             lockingPrice,
             totalBalance,

--- a/contracts/liquidity-reserve/factory/LiquidityReserveFactory.sol
+++ b/contracts/liquidity-reserve/factory/LiquidityReserveFactory.sol
@@ -10,9 +10,12 @@ contract LiquidityReserveFactory {
 
   /**
    * @dev Creates and initialises a new LiquidityReserve
+   * @param _linkToken LINK token address
    * @param _liquidityProvider Lequidity provider address
    * @param _alkemiNetwork Alkemi Network contract address
    * @param _beneficiary earnings beneficiary (address(0) if the earnings goes to the current reserve address)
+   * @param _asset reserve asset
+   * @param _createdAt reserve created time
    * @param _lockingPeriod funds locking period
    * @param _lockingPrice release funds when hitting this price
    * @param _lockingPricePosition locking price position
@@ -24,6 +27,7 @@ contract LiquidityReserveFactory {
     address _alkemiNetwork,
     address _beneficiary,
     address _asset,
+    uint256 _createdAt,
     uint256 _lockingPeriod,
     uint256 _lockingPrice,
     uint8 _lockingPricePosition
@@ -35,6 +39,7 @@ contract LiquidityReserveFactory {
         _alkemiNetwork,
         _beneficiary,
         _asset,
+        _createdAt,
         _lockingPeriod,
         _lockingPrice,
         _lockingPricePosition

--- a/docs/Address.md
+++ b/docs/Address.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Address
-nav_order: 3
 ---
 
 # Address.sol
@@ -82,47 +81,3 @@ function sendValue(address payable recipient, uint256 amount) internal nonpayabl
 | recipient | address payable |  | 
 | amount | uint256 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/AlkemiNetwork.md
+++ b/docs/AlkemiNetwork.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: AlkemiNetwork
-nav_order: 3
 ---
 
 # AlkemiNetwork (AlkemiNetwork.sol)
@@ -67,8 +66,9 @@ modifier onlyAlkemiOracle() internal
 
 - [()](#)
 - [providerLiquidityReserves(address _liquidityProvider)](#providerliquidityreserves)
+- [providerTokenReserves(address _liquidityProvider, address _asset)](#providertokenreserves)
 - [tokenLiquidityReserves(address _asset)](#tokenliquidityreserves)
-- [createLiquidityReserve(address _linkToken, address _beneficiary, address _asset, uint256 _lockingPeriod, uint256 _lockingPrice, uint8 _lockingPricePosition)](#createliquidityreserve)
+- [createLiquidityReserve(address _linkToken, address _beneficiary, address _asset, uint256 _createdAt, uint256 _lockingPeriod, uint256 _lockingPrice, uint8 _lockingPricePosition)](#createliquidityreserve)
 - [setNewOwner(address _owner)](#setnewowner)
 - [setAlkemiOracle(address _oracle)](#setalkemioracle)
 - [_setOwner(address _owner)](#_setowner)
@@ -104,6 +104,26 @@ active liquidity reserve contract addresses
 | ------------- |------------- | -----|
 | _liquidityProvider | address | liquidity provider address | 
 
+### providerTokenReserves
+
+Get liquidity reserves addresses of a liquidity provider that hold specific asset
+
+```js
+function providerTokenReserves(address _liquidityProvider, address _asset) public view
+returns(address[])
+```
+
+**Returns**
+
+active liquidity reserve contract addresses
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+| _liquidityProvider | address | liquidity provider address | 
+| _asset | address | asset address | 
+
 ### tokenLiquidityReserves
 
 Get liquidity reserves addresses that hold a specific asset
@@ -128,7 +148,7 @@ liquidity reserves addresses
 Creates and initialises a new LiquidityReserve
 
 ```js
-function createLiquidityReserve(address _linkToken, address _beneficiary, address _asset, uint256 _lockingPeriod, uint256 _lockingPrice, uint8 _lockingPricePosition) public nonpayable
+function createLiquidityReserve(address _linkToken, address _beneficiary, address _asset, uint256 _createdAt, uint256 _lockingPeriod, uint256 _lockingPrice, uint8 _lockingPricePosition) public nonpayable
 returns(address)
 ```
 
@@ -143,6 +163,7 @@ Address of new Liquidity Reserve
 | _linkToken | address |  | 
 | _beneficiary | address | earnings beneficiary (address(0) if the earnings goes to the current reserve address) | 
 | _asset | address | asset address | 
+| _createdAt | uint256 |  | 
 | _lockingPeriod | uint256 | funds locking period | 
 | _lockingPrice | uint256 | release funds when hitting this price | 
 | _lockingPricePosition | uint8 | locking price position | 
@@ -199,47 +220,3 @@ function _setAlkemiOracle(address _oracle) internal nonpayable
 | ------------- |------------- | -----|
 | _oracle | address |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/AlkemiNetworkMock.md
+++ b/docs/AlkemiNetworkMock.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: AlkemiNetworkMock
-nav_order: 3
 ---
 
 # AlkemiNetworkMock (AlkemiNetworkMock.sol)
@@ -144,47 +143,3 @@ function _setAlkemiOracle(address _oracle) internal nonpayable
 | ------------- |------------- | -----|
 | _oracle | address |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/AlkemiOracle.md
+++ b/docs/AlkemiOracle.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: AlkemiOracle
-nav_order: 3
 ---
 
 # AlkemiOracle.sol
@@ -183,47 +182,3 @@ function stopContainersTrading(uint256 settlementId) internal nonpayable
 | ------------- |------------- | -----|
 | settlementId | uint256 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/Buffer.md
+++ b/docs/Buffer.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Buffer
-nav_order: 3
 ---
 
 # Buffer.sol
@@ -372,47 +371,3 @@ The original buffer.
 | data | uint256 | The data to append. | 
 | len | uint256 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/CBOR.md
+++ b/docs/CBOR.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: CBOR
-nav_order: 3
 ---
 
 # CBOR.sol
@@ -151,47 +150,3 @@ function endSequence(struct Buffer.buffer buf) internal pure
 | ------------- |------------- | -----|
 | buf | struct Buffer.buffer |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/Chainlink.md
+++ b/docs/Chainlink.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Chainlink
-nav_order: 3
 ---
 
 # Library for common Chainlink functions (Chainlink.sol)
@@ -160,47 +159,3 @@ function addStringArray(struct Chainlink.Request self, string _key, string[] _va
 | _key | string | The name of the key | 
 | _values | string[] | The array of string values to add | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/ChainlinkClient.md
+++ b/docs/ChainlinkClient.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: ChainlinkClient
-nav_order: 3
 ---
 
 # The ChainlinkClient contract (ChainlinkClient.sol)
@@ -331,47 +330,3 @@ function validateChainlinkCallback(bytes32 _requestId) internal nonpayable recor
 | ------------- |------------- | -----|
 | _requestId | bytes32 | The request ID for fulfillment | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/ChainlinkOracle.md
+++ b/docs/ChainlinkOracle.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: ChainlinkOracle
-nav_order: 3
 ---
 
 # ChainlinkOracle.sol
@@ -28,47 +27,3 @@ function (address _link) public nonpayable Oracle
 | ------------- |------------- | -----|
 | _link | address |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/ChainlinkRequestInterface.md
+++ b/docs/ChainlinkRequestInterface.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: ChainlinkRequestInterface
-nav_order: 3
 ---
 
 # ChainlinkRequestInterface.sol
@@ -55,47 +54,3 @@ function cancelOracleRequest(bytes32 requestId, uint256 payment, bytes4 callback
 | callbackFunctionId | bytes4 |  | 
 | expiration | uint256 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/Context.md
+++ b/docs/Context.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Context
-nav_order: 3
 ---
 
 # Context.sol
@@ -53,47 +52,3 @@ returns(bytes)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/ENSInterface.md
+++ b/docs/ENSInterface.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: ENSInterface
-nav_order: 3
 ---
 
 # ENSInterface.sol
@@ -121,47 +120,3 @@ returns(uint64)
 | ------------- |------------- | -----|
 | node | bytes32 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/ENSResolver.md
+++ b/docs/ENSResolver.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: ENSResolver
-nav_order: 3
 ---
 
 # ENSResolver.sol
@@ -27,47 +26,3 @@ returns(address)
 | ------------- |------------- | -----|
 | node | bytes32 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/ERC20.md
+++ b/docs/ERC20.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: ERC20
-nav_order: 3
 ---
 
 # ERC20.sol
@@ -320,47 +319,3 @@ function _burnFrom(address account, uint256 amount) internal nonpayable
 | account | address |  | 
 | amount | uint256 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/ERC20Detailed.md
+++ b/docs/ERC20Detailed.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: ERC20Detailed
-nav_order: 3
 ---
 
 # ERC20Detailed.sol
@@ -100,47 +99,3 @@ returns(uint8)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/ERC20Mintable.md
+++ b/docs/ERC20Mintable.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: ERC20Mintable
-nav_order: 3
 ---
 
 # ERC20Mintable.sol
@@ -39,47 +38,3 @@ returns(bool)
 | account | address |  | 
 | amount | uint256 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/EtherTokenConstantMock.md
+++ b/docs/EtherTokenConstantMock.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: EtherTokenConstantMock
-nav_order: 3
 ---
 
 # EtherTokenConstantMock.sol
@@ -34,47 +33,3 @@ returns(address)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/IAlkemiNetwork.md
+++ b/docs/IAlkemiNetwork.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: IAlkemiNetwork
-nav_order: 3
 ---
 
 # IAlkemiNetwork.sol
@@ -92,47 +91,3 @@ returns(bool)
 | surplus | uint128[] | TokensAddresses list of surplus tokens | 
 | deficit | uint128[] | TokensAddresses list of dificit tokens | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/IAlkemiToken.md
+++ b/docs/IAlkemiToken.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: IAlkemiToken
-nav_order: 3
 ---
 
 # IAlkemiToken.sol
@@ -137,47 +136,3 @@ returns(bool)
 | recipient | address |  | 
 | amount | uint256 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/IERC20.md
+++ b/docs/IERC20.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: IERC20
-nav_order: 3
 ---
 
 # IERC20.sol
@@ -154,47 +153,3 @@ returns(bool)
 | recipient | address |  | 
 | amount | uint256 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/ILiquidityReserve.md
+++ b/docs/ILiquidityReserve.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: ILiquidityReserve
-nav_order: 3
 ---
 
 # ILiquidityReserve (ILiquidityReserve.sol)
@@ -12,12 +11,42 @@ View Source: [contracts/interfaces/ILiquidityReserve.sol](../contracts/interface
 
 ## Functions
 
+- [liquidityProvider()](#liquidityprovider)
+- [asset()](#asset)
 - [isActive()](#isactive)
 - [deposit(address _token, uint256 _value)](#deposit)
 - [withdraw(address _token, uint256 _value)](#withdraw)
 - [isUnlocked(address _token)](#isunlocked)
 - [isBeneficiary()](#isbeneficiary)
 - [balance(address _token)](#balance)
+
+### liquidityProvider
+
+Returns the address of the current liquidity provider.
+
+```js
+function liquidityProvider() public view
+returns(address)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
+
+### asset
+
+check if reserve is active
+
+```js
+function asset() external view
+returns(address)
+```
+
+**Arguments**
+
+| Name        | Type           | Description  |
+| ------------- |------------- | -----|
 
 ### isActive
 
@@ -105,47 +134,3 @@ returns(uint256)
 | ------------- |------------- | -----|
 | _token | address |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/ILiquidityReserveFactory.md
+++ b/docs/ILiquidityReserveFactory.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: ILiquidityReserveFactory
-nav_order: 3
 ---
 
 # ILiquidityReserveFactory (ILiquidityReserveFactory.sol)
@@ -39,47 +38,3 @@ Address of new Liquidity Reserve
 | _lockingPrice | uint256 | release funds when hitting this price | 
 | _lockingPricePosition | uint8 | locking price position | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/IOracle.md
+++ b/docs/IOracle.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: IOracle
-nav_order: 3
 ---
 
 # IOracle (IOracle.sol)
@@ -27,47 +26,3 @@ function restartContainersTrading(uint256 settlementId, uint256 settlementTime) 
 | settlementId | uint256 |  | 
 | settlementTime | uint256 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/IOracleGuard.md
+++ b/docs/IOracleGuard.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: IOracleGuard
-nav_order: 3
 ---
 
 # IOracleGuard (IOracleGuard.sol)
@@ -168,47 +167,3 @@ returns(uint256)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/LinkTokenInterface.md
+++ b/docs/LinkTokenInterface.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: LinkTokenInterface
-nav_order: 3
 ---
 
 # LinkTokenInterface.sol
@@ -185,47 +184,3 @@ returns(success bool)
 | to | address |  | 
 | value | uint256 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/LinkTokenReceiver.md
+++ b/docs/LinkTokenReceiver.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: LinkTokenReceiver
-nav_order: 3
 ---
 
 # LinkTokenReceiver.sol
@@ -105,47 +104,3 @@ returns(address)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/LiquidityReserve.md
+++ b/docs/LiquidityReserve.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: LiquidityReserve
-nav_order: 3
 ---
 
 # LiquidityReserve (LiquidityReserve.sol)
@@ -35,6 +34,7 @@ uint256 internal _amountToWithdraw;
 //public members
 address public asset;
 address public beneficiary;
+uint256 public createdAt;
 uint256 public lockingPeriod;
 uint256 public lockingPrice;
 uint256 public totalBalance;
@@ -59,7 +59,7 @@ event PriceUnlock(uint256  lockingPrice, uint256  oraclePrice, uint256  lockingP
 
 ## Functions
 
-- [(address _link, address _liquidityProvider, address _alkemiNetwork, address _beneficiary, address _asset, uint256 _lockingPeriod, uint256 _lockingPrice, uint8 _lockingPricePosition)](#)
+- [(address _link, address _liquidityProvider, address _alkemiNetwork, address _beneficiary, address _asset, uint256 _createdAt, uint256 _lockingPeriod, uint256 _lockingPrice, uint8 _lockingPricePosition)](#)
 - [isActive()](#isactive)
 - [balance(address _token)](#balance)
 - [isBeneficiary()](#isbeneficiary)
@@ -81,18 +81,19 @@ event PriceUnlock(uint256  lockingPrice, uint256  oraclePrice, uint256  lockingP
 constructor
 
 ```js
-function (address _link, address _liquidityProvider, address _alkemiNetwork, address _beneficiary, address _asset, uint256 _lockingPeriod, uint256 _lockingPrice, uint8 _lockingPricePosition) public nonpayable LiquidityReserveState 
+function (address _link, address _liquidityProvider, address _alkemiNetwork, address _beneficiary, address _asset, uint256 _createdAt, uint256 _lockingPeriod, uint256 _lockingPrice, uint8 _lockingPricePosition) public nonpayable LiquidityReserveState 
 ```
 
 **Arguments**
 
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
-| _link | address |  | 
+| _link | address | LINK token address | 
 | _liquidityProvider | address | liquidity provider address | 
 | _alkemiNetwork | address | Alkemi Network contract address | 
 | _beneficiary | address | earnings beneficiary (address(0) if the earnings goes to the current reserve address) | 
-| _asset | address |  | 
+| _asset | address | reserve asset | 
+| _createdAt | uint256 | reserve created time | 
 | _lockingPeriod | uint256 | funds locking period | 
 | _lockingPrice | uint256 | release funds when hitting this price | 
 | _lockingPricePosition | uint8 | locking price position | 
@@ -150,7 +151,7 @@ Get reserve details
 
 ```js
 function details() public view
-returns(address, uint256, uint256, uint256, uint256, uint256)
+returns(address, uint256, uint256, uint256, uint256, uint256, uint256)
 ```
 
 **Returns**
@@ -325,47 +326,3 @@ function _withdraw(address payable _recepient, address _token, uint256 _value) i
 | _token | address |  | 
 | _value | uint256 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/LiquidityReserveFactory.md
+++ b/docs/LiquidityReserveFactory.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: LiquidityReserveFactory
-nav_order: 3
 ---
 
 # LiquidityReserveFactory (LiquidityReserveFactory.sol)
@@ -16,14 +15,14 @@ This Factory creates a Liquidity Reserve
 
 ## Functions
 
-- [_createLiquidityReserve(address _linkToken, address _liquidityProvider, address _alkemiNetwork, address _beneficiary, address _asset, uint256 _lockingPeriod, uint256 _lockingPrice, uint8 _lockingPricePosition)](#_createliquidityreserve)
+- [_createLiquidityReserve(address _linkToken, address _liquidityProvider, address _alkemiNetwork, address _beneficiary, address _asset, uint256 _createdAt, uint256 _lockingPeriod, uint256 _lockingPrice, uint8 _lockingPricePosition)](#_createliquidityreserve)
 
 ### _createLiquidityReserve
 
 Creates and initialises a new LiquidityReserve
 
 ```js
-function _createLiquidityReserve(address _linkToken, address _liquidityProvider, address _alkemiNetwork, address _beneficiary, address _asset, uint256 _lockingPeriod, uint256 _lockingPrice, uint8 _lockingPricePosition) internal nonpayable
+function _createLiquidityReserve(address _linkToken, address _liquidityProvider, address _alkemiNetwork, address _beneficiary, address _asset, uint256 _createdAt, uint256 _lockingPeriod, uint256 _lockingPrice, uint8 _lockingPricePosition) internal nonpayable
 returns(address)
 ```
 
@@ -35,56 +34,13 @@ Address of new Liquidity Reserve
 
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
-| _linkToken | address |  | 
+| _linkToken | address | LINK token address | 
 | _liquidityProvider | address | Lequidity provider address | 
 | _alkemiNetwork | address | Alkemi Network contract address | 
 | _beneficiary | address | earnings beneficiary (address(0) if the earnings goes to the current reserve address) | 
-| _asset | address |  | 
+| _asset | address | reserve asset | 
+| _createdAt | uint256 | reserve created time | 
 | _lockingPeriod | uint256 | funds locking period | 
 | _lockingPrice | uint256 | release funds when hitting this price | 
 | _lockingPricePosition | uint8 | locking price position | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/LiquidityReserveState.md
+++ b/docs/LiquidityReserveState.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: LiquidityReserveState
-nav_order: 3
 ---
 
 # LiquidityReserveState.sol
@@ -198,47 +197,3 @@ function _transferLiquidityProvider(address newLiquidityprovider) internal nonpa
 | ------------- |------------- | -----|
 | newLiquidityprovider | address |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/Migrations.md
+++ b/docs/Migrations.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Migrations
-nav_order: 3
 ---
 
 # Migrations.sol
@@ -75,47 +74,3 @@ function upgrade(address new_address) public nonpayable restricted
 | ------------- |------------- | -----|
 | new_address | address |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/MinterRole.md
+++ b/docs/MinterRole.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: MinterRole
-nav_order: 3
 ---
 
 # MinterRole.sol
@@ -123,47 +122,3 @@ function _removeMinter(address account) internal nonpayable
 | ------------- |------------- | -----|
 | account | address |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/Oracle.md
+++ b/docs/Oracle.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Oracle
-nav_order: 3
 ---
 
 # The Chainlink Oracle contract (Oracle.sol)
@@ -289,47 +288,3 @@ returns(address)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/OracleGuard.md
+++ b/docs/OracleGuard.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: OracleGuard
-nav_order: 3
 ---
 
 # OracleGuard.sol
@@ -278,47 +277,3 @@ function setTokenContract(address _alkemiToken) external nonpayable auth
 | ------------- |------------- | -----|
 | _alkemiToken | address | Alkemi Token address | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/OracleInterface.md
+++ b/docs/OracleInterface.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: OracleInterface
-nav_order: 3
 ---
 
 # OracleInterface.sol
@@ -99,47 +98,3 @@ returns(uint256)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/Ownable.md
+++ b/docs/Ownable.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Ownable
-nav_order: 3
 ---
 
 # Ownable.sol
@@ -129,47 +128,3 @@ function _transferOwnership(address newOwner) internal nonpayable
 | ------------- |------------- | -----|
 | newOwner | address |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/PointerInterface.md
+++ b/docs/PointerInterface.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: PointerInterface
-nav_order: 3
 ---
 
 # PointerInterface.sol
@@ -26,47 +25,3 @@ returns(address)
 | Name        | Type           | Description  |
 | ------------- |------------- | -----|
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/Roles.md
+++ b/docs/Roles.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Roles
-nav_order: 3
 ---
 
 # Roles (Roles.sol)
@@ -77,47 +76,3 @@ bool
 | role | struct Roles.Role |  | 
 | account | address |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/SafeERC20.md
+++ b/docs/SafeERC20.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: SafeERC20
-nav_order: 3
 ---
 
 # SafeERC20 (SafeERC20.sol)
@@ -113,47 +112,3 @@ function callOptionalReturn(IERC20 token, bytes data) private nonpayable
 | token | IERC20 | The token targeted by the call. | 
 | data | bytes | The call data (encoded using abi.encode or one of its variants). | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/SafeMath.md
+++ b/docs/SafeMath.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: SafeMath
-nav_order: 3
 ---
 
 # SafeMath.sol
@@ -132,47 +131,3 @@ returns(uint256)
 | a | uint256 |  | 
 | b | uint256 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/docs/TokenMock.md
+++ b/docs/TokenMock.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: TokenMock
-nav_order: 3
 ---
 
 # TokenMock.sol
@@ -32,47 +31,3 @@ function (string name, string symbol, uint8 decimals) public nonpayable ERC20Det
 | symbol | string |  | 
 | decimals | uint8 |  | 
 
-## Contracts
-
-* [Address](Address.md)
-* [AlkemiNetwork](AlkemiNetwork.md)
-* [AlkemiNetworkMock](AlkemiNetworkMock.md)
-* [AlkemiOracle](AlkemiOracle.md)
-* [AlkemiSettlementMock](AlkemiSettlementMock.md)
-* [Buffer](Buffer.md)
-* [CBOR](CBOR.md)
-* [Chainlink](Chainlink.md)
-* [ChainlinkClient](ChainlinkClient.md)
-* [ChainlinkOracle](ChainlinkOracle.md)
-* [ChainlinkRequestInterface](ChainlinkRequestInterface.md)
-* [Context](Context.md)
-* [ENSInterface](ENSInterface.md)
-* [ENSResolver](ENSResolver.md)
-* [ERC20](ERC20.md)
-* [ERC20Detailed](ERC20Detailed.md)
-* [ERC20Mintable](ERC20Mintable.md)
-* [EtherTokenConstantMock](EtherTokenConstantMock.md)
-* [IAlkemiNetwork](IAlkemiNetwork.md)
-* [IAlkemiSettlement](IAlkemiSettlement.md)
-* [IAlkemiToken](IAlkemiToken.md)
-* [IERC20](IERC20.md)
-* [ILiquidityReserve](ILiquidityReserve.md)
-* [ILiquidityReserveFactory](ILiquidityReserveFactory.md)
-* [IOracle](IOracle.md)
-* [IOracleGuard](IOracleGuard.md)
-* [LinkTokenInterface](LinkTokenInterface.md)
-* [LinkTokenReceiver](LinkTokenReceiver.md)
-* [LiquidityReserve](LiquidityReserve.md)
-* [LiquidityReserveFactory](LiquidityReserveFactory.md)
-* [LiquidityReserveState](LiquidityReserveState.md)
-* [Migrations](Migrations.md)
-* [MinterRole](MinterRole.md)
-* [Oracle](Oracle.md)
-* [OracleGuard](OracleGuard.md)
-* [OracleInterface](OracleInterface.md)
-* [Ownable](Ownable.md)
-* [PointerInterface](PointerInterface.md)
-* [Roles](Roles.md)
-* [SafeERC20](SafeERC20.md)
-* [SafeMath](SafeMath.md)
-* [TokenMock](TokenMock.md)

--- a/test/LiquidityReserve.js
+++ b/test/LiquidityReserve.js
@@ -89,6 +89,7 @@ contract('Alkemi Liquidity Reserve', ([alkemiTeam, liquidityProvider1, liquidity
         linkToken.address,
         ZERO_ADDR,
         token1.address,
+        now,
         lockingPeriod,
         lockingPrice,
         lockingPricePosition,


### PR DESCRIPTION
## Description

This PR add the feature of getting a reserve creation time.
It add a `createdAt` field to the reserve constructor, a public field than be called directly or getted using the `details()` function.

Fixes # (issue)

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
